### PR TITLE
fix: rename npm script quality to lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,3 @@ node_js:
   - "4"
 script:
   - npm run lint
-  - npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Grunt multi-task for discovering orphaned files in a JS directory.",
   "main": "tasks/grunt-orphans.js",
   "scripts": {
-    "quality": "grunt audit lint"
+    "lint": "grunt audit lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- The .travis.yml file is looking for npm run lint
- rename quality to lint
- remove npm test from the .travis.yml